### PR TITLE
fix readyThrow stuck

### DIFF
--- a/src/main/java/com/puddingkc/TridentDupeFixer.java
+++ b/src/main/java/com/puddingkc/TridentDupeFixer.java
@@ -42,7 +42,8 @@ public class TridentDupeFixer extends JavaPlugin implements Listener {
 
     @EventHandler
     public void onPlayerInteract(PlayerInteractEvent event) {
-        if (event.getItem() == null) { return; }
+        ItemStack item = event.getItem();
+        if (item == null) { return; }
 
         if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
             if (item.getType() == Material.TRIDENT && !item.containsEnchantment(Enchantment.RIPTIDE)) {

--- a/src/main/java/com/puddingkc/TridentDupeFixer.java
+++ b/src/main/java/com/puddingkc/TridentDupeFixer.java
@@ -45,7 +45,7 @@ public class TridentDupeFixer extends JavaPlugin implements Listener {
         if (event.getItem() == null) { return; }
 
         if (event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-            if (event.getItem().getType() == Material.TRIDENT) {
+            if (item.getType() == Material.TRIDENT && !item.containsEnchantment(Enchantment.RIPTIDE)) {
                 readyThrow.add(event.getPlayer().getUniqueId());
             }
         }


### PR DESCRIPTION
readyThrow stucks since riptide doesn't launch the projectile. It leads to players can't click their items even they are doesn't anything with a trident.

p.s.: Riptide prevents this exploit so we can safely ignore tridents which has riptide enchantment.